### PR TITLE
Add version number and revision date to generated Quick Start guides

### DIFF
--- a/cityehr-quick-start-guide/pom.xml
+++ b/cityehr-quick-start-guide/pom.xml
@@ -116,6 +116,16 @@
                                     <dir>${lwdita.src}</dir>
                                     <includes>quickstart-guide.ditamap</includes>
                                     <stylesheet>src/main/xslt/create-map-pdf.xslt</stylesheet>
+                                    <parameters>
+                                        <parameter>
+                                            <name>version</name>
+                                            <value>${project.version}</value>
+                                        </parameter>
+                                        <parameter>
+                                            <name>revision</name>
+                                            <value>${maven.build.timestamp}</value>
+                                        </parameter>
+                                    </parameters>
                                     <outputDir>${fo.generated-resources}</outputDir>
                                     <fileMappers>
                                         <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">

--- a/cityehr-quick-start-guide/pom.xml
+++ b/cityehr-quick-start-guide/pom.xml
@@ -250,6 +250,14 @@
                                             <stylesheet>src/main/xslt/create-map-html.xslt</stylesheet>
                                             <parameters>
                                                 <parameter>
+                                                    <name>version</name>
+                                                    <value>${project.version}</value>
+                                                </parameter>
+                                                <parameter>
+                                                    <name>revision</name>
+                                                    <value>${maven.build.timestamp}</value>
+                                                </parameter>
+                                                <parameter>
                                                     <name>download-pdf-filename</name>
                                                     <value>quickstart-guide.pdf</value>
                                                 </parameter>

--- a/cityehr-quick-start-guide/src/main/xslt/common-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/common-html.xslt
@@ -16,19 +16,20 @@
 
   <xsl:template name="hcom:meta">
     <xsl:param name="authors" as="xs:string+" required="yes"/>
-    <xsl:param name="created-date" as="xs:date?" required="no"/>
-    <xsl:param name="modified-date" as="xs:date?" required="no"/>
+    <xsl:param name="version" as="xs:string" required="yes"/>
+    <xsl:param name="created-dateTime" as="xs:dateTime?" required="no"/>
+    <xsl:param name="modified-dateTime" as="xs:dateTime?" required="no"/>
     <xsl:apply-templates select="topicmeta|title" mode="metadata"/>
     <xsl:call-template name="hcom:authors-meta">
       <xsl:with-param name="authors" select="$authors"/>
     </xsl:call-template>
     <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
     <meta name="DCTERMS.creator" content="https://seveninformatics.com"/>
-    <xsl:if test="exists($created-date)">
-      <meta name="DCTERMS.created" content="{$created-date}"/>
+    <xsl:if test="exists($created-dateTime)">
+      <meta name="DCTERMS.created" content="{$created-dateTime}"/>
     </xsl:if>
-    <xsl:if test="exists($modified-date)">
-      <meta name="DCTERMS.modified" content="{$modified-date}"/>
+    <xsl:if test="exists($modified-dateTime)">
+      <meta name="DCTERMS.modified" content="{$modified-dateTime}"/>
     </xsl:if>
   </xsl:template>
   
@@ -89,5 +90,14 @@
     <xsl:param name="dita-filename" as="xs:string" required="yes"/>
     <xsl:sequence select="replace($dita-filename, '\.dita(map)?$', '.html')"/>
   </xsl:function>
-  
+
+  <!--
+  Adjust a date to UTC timezone and then formats it as
+  nth Month Year.
+  -->
+  <xsl:function name="hcom:simple-date-utc-from-dateTime" as="xs:string">
+    <xsl:param name="dateTime" as="xs:dateTime" required="yes"/>
+    <xsl:sequence select="format-dateTime(adjust-dateTime-to-timezone($dateTime, xs:dayTimeDuration('PT0H')), '[D1o] [MNn] [Y0001]')"/>
+  </xsl:function>
+
 </xsl:stylesheet>

--- a/cityehr-quick-start-guide/src/main/xslt/common-pdf.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/common-pdf.xslt
@@ -106,7 +106,8 @@
     <xsl:param name="title" as="xs:string" required="yes"/>
     <xsl:param name="sub-title" as="xs:string?" required="no"/>
     <xsl:param name="authors" as="xs:string+" required="yes"/>
-    <xsl:param name="date" as="xs:date" required="no" select="current-date()"/>
+    <xsl:param name="version" as="xs:string" required="no" select="'1.0.0-SNAPSHOT'"/>
+    <xsl:param name="revision" as="xs:dateTime" required="no" select="current-dateTime()"/>
     <fo:page-sequence master-reference="PageMaster" id="cover-page-sequence">
       <xsl:apply-templates mode="cover-page-sequence-setup"/>
       <fo:static-content flow-name="xsl-region-before">
@@ -127,7 +128,8 @@
           <fo:block font-size="14pt"><xsl:value-of select="$title"/></fo:block>
           <fo:block font-size="14pt"><xsl:value-of select="$sub-title"/></fo:block>
           <fo:block font-size="12pt"><xsl:value-of select="com:format-inline-text-list($authors)"/></fo:block>
-          <fo:block font-size="12pt"><xsl:value-of select="pcom:simple-date-utc($date)"/></fo:block>          
+          <fo:block font-size="9pt"><fo:inline font-weight="bold">Version: </fo:inline><xsl:value-of select="$version"/></fo:block>
+          <fo:block font-size="9pt"><fo:inline font-weight="bold">Revision: </fo:inline><xsl:value-of select="pcom:simple-date-utc-from-dateTime($revision)"/></fo:block>
         </fo:block>
       </fo:flow>
     </fo:page-sequence>
@@ -220,9 +222,9 @@
     Adjust a date to UTC timezone and then formats it as
     nth Month Year.
   -->
-  <xsl:function name="pcom:simple-date-utc" as="xs:string">
-    <xsl:param name="date" as="xs:date" required="yes"/>
-    <xsl:sequence select="format-date(adjust-date-to-timezone($date, xs:dayTimeDuration('PT0H')), '[D1o] [MNn] [Y0001]')"/>
+  <xsl:function name="pcom:simple-date-utc-from-dateTime" as="xs:string">
+    <xsl:param name="dateTime" as="xs:dateTime" required="yes"/>
+    <xsl:sequence select="format-dateTime(adjust-dateTime-to-timezone($dateTime, xs:dayTimeDuration('PT0H')), '[D1o] [MNn] [Y0001]')"/>
   </xsl:function>
 
 </xsl:stylesheet>

--- a/cityehr-quick-start-guide/src/main/xslt/common-pdf.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/common-pdf.xslt
@@ -68,7 +68,7 @@
             <xsl:if test="$producer">
               <pdf:Producer><xsl:value-of select="$producer"/></pdf:Producer>
             </xsl:if>
-            <xmp:CreationDate><xsl:value-of select="pcom:iso8601-dateTime-utc($created)"/></xmp:CreationDate>
+            <xmp:CreateDate><xsl:value-of select="pcom:iso8601-dateTime-utc($created)"/></xmp:CreateDate>
             <xmp:ModifyDate><xsl:value-of select="pcom:iso8601-dateTime-utc($modified)"/></xmp:ModifyDate>
           </rdf:Description>
         </rdf:RDF>

--- a/cityehr-quick-start-guide/src/main/xslt/create-map-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-map-html.xslt
@@ -20,7 +20,7 @@
   <!-- PARAMETER - the path to the folder where you want to output the Topic HTML files -->
   <xsl:param name="output-folder" as="xs:string" select="com:parent-path(com:document-uri(/map))"/>
   
-  <!-- PARAMETER - specifing a PDF file version of this to present a download link for -->
+  <!-- PARAMETER - specifying a PDF file version of this to present a download link for -->
   <xsl:param name="download-pdf-filename" as="xs:string?"/>
   
   <xsl:variable name="authors" as="xs:string+" select="('John Chelsom', 'Stephanie Cabrera', 'Catriona Hopper', 'Jennifer Ramirez')"/>

--- a/cityehr-quick-start-guide/src/main/xslt/create-map-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-map-html.xslt
@@ -16,6 +16,12 @@
   <xsl:import href="create-topic-html.xslt"/>
   
   <xsl:output method="html" version="5.0" encoding="UTF-8" indent="yes"/>
+
+  <!-- PARAMETER - the version number of the generated document -->
+  <xsl:param name="version" required="yes" as="xs:string"/>
+
+  <!-- PARAMETER - the revision date and time of the generated document -->
+  <xsl:param name="revision" required="no" as="xs:dateTime" select="current-dateTime()"/>
   
   <!-- PARAMETER - the path to the folder where you want to output the Topic HTML files -->
   <xsl:param name="output-folder" as="xs:string" select="com:parent-path(com:document-uri(/map))"/>
@@ -24,7 +30,6 @@
   <xsl:param name="download-pdf-filename" as="xs:string?"/>
   
   <xsl:variable name="authors" as="xs:string+" select="('John Chelsom', 'Stephanie Cabrera', 'Catriona Hopper', 'Jennifer Ramirez')"/>
-  <xsl:variable name="map-date" as="xs:date" select="xs:date('2023-08-05Z')"/>
 
   <!-- NOTE(AR) used for building the top-nav and bottom-nav -->
   <xsl:variable name="map-uri" as="xs:string" select="com:document-uri(/map)"/>
@@ -35,8 +40,9 @@
       <head>
         <xsl:call-template name="hcom:meta">
           <xsl:with-param name="authors" select="$authors"/>
-          <xsl:with-param name="created-date" select="$map-date"/>
-          <xsl:with-param name="modified-date" select="$map-date"/>
+          <xsl:with-param name="version" select="$version"/>
+          <xsl:with-param name="created-dateTime" select="$revision"/>
+          <xsl:with-param name="modified-dateTime" select="$revision"/>
         </xsl:call-template>
       </head>
       <body about="">
@@ -47,7 +53,7 @@
           <xsl:apply-templates select="topicmeta" mode="cover-page"/>
         </div>
         <article typeof="cc:Work">
-          <time datetime="{$map-date}" pubdate="pubdate"></time>
+          <time datetime="{$revision}" pubdate="pubdate"></time>
           <xsl:apply-templates select="topicmeta" mode="body"/>
           <xsl:if test="exists($download-pdf-filename)">
             <div id="download-pdf-version"><a href="{$download-pdf-filename}">Download PDF version</a></div>
@@ -63,6 +69,10 @@
   </xsl:template>
   
   <xsl:template match="topicmeta" mode="cover-page">
+    <div id="version" style="font-size: 9pt;">
+      <p><b>Version:</b> <xsl:value-of select="$version"/></p>
+      <p><b>Revision:</b> <xsl:value-of select="hcom:simple-date-utc-from-dateTime($revision)"/></p>
+    </div>
     <div id="license" style="display: flex; align-items: center; justify-content: left">
       <div id="license-image" style="max-width: 100%; max-height:100%;">
         <a rel="license" href="{othermeta[@name eq 'dcterms:license'][2]/@content}"><img src="images/by-nc-sa.png" width="30%"/></a>

--- a/cityehr-quick-start-guide/src/main/xslt/create-map-pdf.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-map-pdf.xslt
@@ -17,11 +17,16 @@
   <xsl:import href="common.xslt"/>
   <xsl:import href="common-pdf.xslt"/>
   <xsl:import href="create-topic-pdf.xslt"/>
-  
+
   <xsl:output encoding="UTF-8" omit-xml-declaration="no" indent="yes"/>
+
+  <!-- PARAMETER - the version number of the generated document -->
+  <xsl:param name="version" required="yes" as="xs:string"/>
+
+  <!-- PARAMETER - the revision date and time of the generated document -->
+  <xsl:param name="revision" required="no" as="xs:dateTime" select="current-dateTime()"/>
   
   <xsl:variable name="authors" as="xs:string+" select="('John Chelsom', 'Stephanie Cabrera', 'Catriona Hopper', 'Jennifer Ramirez')"/>
-  <xsl:variable name="map-date" as="xs:date" select="xs:date('2024-10-05Z')"/>
   
   <xsl:template match="document-node()">
     <xsl:call-template name="pcom:fo-root"/>
@@ -70,7 +75,8 @@
       <xsl:with-param name="title" select="topicmeta/navtitle"/>
       <xsl:with-param name="sub-title">Open Health Informatics</xsl:with-param>
       <xsl:with-param name="authors" select="$authors"/>
-      <xsl:with-param name="date" select="$map-date"/>
+      <xsl:with-param name="version" select="$version"/>
+      <xsl:with-param name="revision" select="$revision"/>
     </xsl:call-template>
   </xsl:template>
   

--- a/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
@@ -18,6 +18,12 @@
 
   <xsl:output method="html" version="5.0" encoding="UTF-8" indent="yes"/>
 
+  <!-- PARAMETER - the version number of the generated document -->
+  <xsl:param name="version" required="yes" as="xs:string"/>
+  
+  <!-- PARAMETER - the revision date and time of the generated document -->
+  <xsl:param name="revision" required="no" as="xs:dateTime" select="current-dateTime()"/>
+
   <xsl:param name="petal-api-url"           as="xs:string" required="yes"/>
   <xsl:param name="petal-github-org-name"   as="xs:string" required="yes"/>
   <xsl:param name="petal-github-repo-name"  as="xs:string" required="yes"/>
@@ -31,6 +37,9 @@
       <head>
         <xsl:call-template name="hcom:meta">
           <xsl:with-param name="authors" select="$authors"/>
+          <xsl:with-param name="version" select="$version"/>
+          <xsl:with-param name="created-dateTime" select="$revision"/>
+          <xsl:with-param name="modified-dateTime" select="$revision"/>
         </xsl:call-template>
       </head>
       <body>

--- a/cityehr-quick-start-guide/src/test/xspec/create-topic-html.xspec
+++ b/cityehr-quick-start-guide/src/test/xspec/create-topic-html.xspec
@@ -4,7 +4,8 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:htop="http://cityehr/html/topic"
   stylesheet="../../main/xslt/create-topic-html.xslt">
-  
+
+  <x:param name="version"                 as="xs:string">xspec-test-version</x:param>
   <x:param name="petal-api-url"           as="xs:string">https://petal.evolvedbinary.com</x:param>
   <x:param name="petal-github-org-name"   as="xs:string">evolvedbinary</x:param>
   <x:param name="petal-github-repo-name"  as="xs:string">cityehr-documentation</x:param>


### PR DESCRIPTION
This adds both the project version number and a revision date (from the build date) to the generated PDF and HTML Topic's of the Quick Start guide.